### PR TITLE
Support versions of Node >14

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": "14"
+    "node": ">= 14.0.0"
   },
   "peerDependencies": {
     "aws-sdk": "2.952.0"


### PR DESCRIPTION
Whilst the latest Lambda Node.js runtime is v14, AFAICT it's reasonable to deploy serverless-handlers in a Node.js v16 project that uses babel to transpile lambdas to target v14?