### PR TITLE
Pass through arbitrary additional arguments to handler

### DIFF
--- a/src/lambda-handlers/json/index.js
+++ b/src/lambda-handlers/json/index.js
@@ -5,7 +5,7 @@ export default function handler(fn) {
     throw new Error('Expected a handler function.');
   }
 
-  return async (event) => {
+  return async (event, ...args) => {
     let requestBody;
 
     try {
@@ -16,6 +16,6 @@ export default function handler(fn) {
       // appropriately (probably with a 400 Bad Request status).
     }
 
-    return fn(requestBody, event);
+    return fn(requestBody, event, ...args);
   };
 }

--- a/src/lambda-handlers/json/index.spec.js
+++ b/src/lambda-handlers/json/index.spec.js
@@ -21,4 +21,28 @@ describe('JSON request handler', () => {
     await wrappedHandler(mockEvent);
     expect(handler.mock.calls[0][0]).toBe(undefined);
   });
+
+  it('should pass parsed JSON to the handler function', async () => {
+    const mockEvent = {
+      body: '{"foo": "bar"}',
+    };
+    const handler = jest.fn().mockReturnValue({});
+    const wrappedHandler = makeHandler(handler);
+
+    await wrappedHandler(mockEvent);
+    expect(handler.mock.calls[0][0]).toMatchObject({ foo: 'bar' });
+  });
+
+  it('should pass-through underlying arguments', async () => {
+    const mockEvent = {
+      body: '{"foo": "bar"}',
+    };
+    const handler = jest.fn().mockReturnValue({});
+    const wrappedHandler = makeHandler(handler);
+
+    await wrappedHandler(mockEvent, 1, 2, 3);
+    expect(handler.mock.calls[0][2]).toBe(1);
+    expect(handler.mock.calls[0][3]).toBe(2);
+    expect(handler.mock.calls[0][4]).toBe(3);
+  });
 });


### PR DESCRIPTION
The JSON handler wrapper previously only provided the raw event object
alongside the parsed request body meaning the underlying handler lost
access to the raw context object. This resolves that by passing through
any arbitrary arguments following the event object.